### PR TITLE
Add support for wstring

### DIFF
--- a/miniutf.hpp
+++ b/miniutf.hpp
@@ -32,6 +32,7 @@ namespace miniutf {
  */
 void utf8_encode(char32_t pt, std::string & out);
 void utf16_encode(char32_t pt, std::u16string & out);
+void utf16_encode(char32_t pt, std::wstring & out);
 
 /*
  * Character-at-a-time decoding. Decodes and returns the codepoint starting at str[pos],
@@ -43,8 +44,13 @@ void utf16_encode(char32_t pt, std::u16string & out);
 char32_t utf8_decode(const std::string & str,
                      std::string::size_type & pos,
                      bool * replacement_flag = nullptr);
+
 char32_t utf16_decode(const std::u16string & str,
                       std::u16string::size_type & pos,
+                      bool * replacement_flag = nullptr);
+
+char32_t utf16_decode(const std::wstring & str,
+                      std::wstring::size_type & pos,
                       bool * replacement_flag = nullptr);
 
 /*
@@ -72,6 +78,12 @@ std::u32string to_utf32(const std::string & str);
 std::u16string to_utf16(const std::string & str);
 std::string to_utf8(const std::u16string & str);
 std::string to_utf8(const std::u32string & str);
+
+/*
+ * Convert back and forth between UTF-8 and UTF-16 from wstring.
+ */
+std::string to_utf8(const std::wstring & str);
+std::wstring to_utf16w(const std::string &str);
 
 /*
  * Convert str to lowercase, per the built-in Unicode lowercasing map (codepoint-by-codepoint).

--- a/test.cpp
+++ b/test.cpp
@@ -180,15 +180,28 @@ int main(void) {
 
     string utf8_test = { '\x61', '\x00', '\xF0', '\x9F', '\x92', '\xA9' };
     std::u16string utf16_test = { 0x61, 0, 0xD83D, 0xDCA9 };
+    std::wstring utf16w_test = { 0x61, 0, 0xD83D, 0xDCA9 };
 
     // We also have some tests of UTF-8 to UTF-16 conversion
     string utf8 = miniutf::to_utf8(utf16_test);
     if (!check_eq("16-to-8", utf8_test, utf8))
         return 1;
 
+    string utf8w = miniutf::to_utf8(utf16w_test);
+    if (!check_eq("16-to-8", utf8_test, utf8w))
+        return 1;
+
     std::u16string utf16 = miniutf::to_utf16(utf8_test);
     if (utf16 != utf16_test) {
         printf("utf8-to-utf16 test failed: got ");
+        for (size_t i = 0; i < utf16.length(); i++) printf("%04x ", (uint16_t)utf16[i]);
+        printf("\n");
+        return 1;
+    }
+
+    std::wstring utf16w = miniutf::to_utf16w(utf8_test);
+    if (utf16w != utf16w_test) {
+        printf("utf8-to-utf16w test failed: got ");
         for (size_t i = 0; i < utf16.length(); i++) printf("%04x ", (uint16_t)utf16[i]);
         printf("\n");
         return 1;


### PR DESCRIPTION
miniutf can now convert from and to wstring. The assumption here is that wstring is encoded as UTF-16. Since it’s either 2 (MSVC) or 4 bytes (Clang, GCC) depending on compiler, we can’t assume it holds UTF-32. If it holds UTF-8, the conversion is trivial and minutf is not needed. In practice every function that took or returned `u16string` now has a `wstring` match.

I used templates to ensure we don’t have repetitive code. For simplicity reasons, no templates are exposed in the header though.

Tests have been added, however the test spec is quite minimal.

I'm not sure if this is something Dropbox would like to merge upstream. We have code that still uses `wstring` and having 1st-class support in miniutf is more efficient than converting the string beforehand. Also, the actual added code is minimal; this is all achieved through templated functions.

Anyway, thanks for this library! While we initially used `codecvt_utf8_utf16`, this library turns out to be both more portable and more flexible in terms of converting strings with invalid UTF-data.
